### PR TITLE
Added missing include of libewf_libcstring.h

### DIFF
--- a/libewf/libewf_hash_sections.c
+++ b/libewf/libewf_hash_sections.c
@@ -23,6 +23,7 @@
 #include <memory.h>
 
 #include "libewf_libcerror.h"
+#include "libewf_libcstring.h"
 #include "libewf_hash_sections.h"
 #include "libewf_hash_values.h"
 


### PR DESCRIPTION
Without the include, libcstring_narrow_string_compare is never defined in this source file, which causes libewf to have an undefined symbol, which causes linking the ewftools to fail.