### PR TITLE
Extends pyewf bindings to include get_file_type function for file_entry objects

### DIFF
--- a/pyewf/pyewf_file_entry.c
+++ b/pyewf/pyewf_file_entry.c
@@ -177,6 +177,13 @@ PyMethodDef pyewf_file_entry_object_methods[] = {
 	  "\n"
 	  "Retrieves the SHA1 hash of the file entry data." },
 
+	{ "get_file_type",
+	  (PyCFunction) pyewf_file_entry_get_file_type,
+	  METH_NOARGS,
+	  "get_file_type() -> Integer\n"
+	  "\n"
+	  "Returns the file type of the file entry." },
+
 	/* Functions to access the sub file entries */
 
 	{ "get_number_of_sub_file_entries",
@@ -258,6 +265,13 @@ PyGetSetDef pyewf_file_entry_object_get_set_definitions[] = {
 	  (setter) 0,
 	  "The sub file entries",
 	  NULL },
+
+	{ "file_type",
+		(getter) pyewf_file_entry_get_file_type,
+		(setter) 0,
+		"The file type of the file entry.",
+		NULL },
+
 
 	/* Sentinel */
 	{ NULL, NULL, NULL, NULL, NULL }
@@ -1871,3 +1885,53 @@ PyObject *pyewf_file_entry_get_sub_file_entries(
 	return( file_entries_object );
 }
 
+/* Retrieves the file type
+ * Returns a Python object if successful or NULL on error
+ */
+PyObject *pyewf_file_entry_get_file_type(
+           pyewf_file_entry_t *pyewf_file_entry,
+           PyObject *arguments PYEWF_ATTRIBUTE_UNUSED )
+{
+	libcerror_error_t *error = NULL;
+	PyObject *integer_object = NULL;
+	static char *function    = "pyewf_file_entry_get_file_type";
+	uint8_t type             = 0;
+	int result               = 0;
+
+	PYEWF_UNREFERENCED_PARAMETER( arguments )
+
+	if( pyewf_file_entry == NULL )
+	{
+		PyErr_Format(
+		 PyExc_TypeError,
+		 "%s: invalid file entry.",
+		 function );
+
+		return( NULL );
+	}
+	Py_BEGIN_ALLOW_THREADS
+
+	result = libewf_file_entry_get_type(
+	          pyewf_file_entry->file_entry,
+	          &type,
+	          &error );
+
+	Py_END_ALLOW_THREADS
+
+	if( result != 1 )
+	{
+		pyewf_error_raise(
+		 error,
+		 PyExc_IOError,
+		 "%s: unable to retrieve file type.",
+		 function );
+
+		libcerror_error_free(
+		 &error );
+
+		return( NULL );
+	}
+	integer_object = PyLong_FromLong((long) type);
+
+	return( integer_object );
+}

--- a/pyewf/pyewf_file_entry.h
+++ b/pyewf/pyewf_file_entry.h
@@ -147,9 +147,12 @@ PyObject *pyewf_file_entry_get_sub_file_entries(
            pyewf_file_entry_t *pyewf_file_entry,
            PyObject *arguments );
 
+PyObject *pyewf_file_entry_get_file_type(
+          pyewf_file_entry_t *pyewf_file_entry,
+          PyObject *arguments );
+
 #if defined( __cplusplus )
 }
 #endif
 
 #endif /* !defined( _PYEWF_FILE_ENTRY_H ) */
-

--- a/synclibs.sh
+++ b/synclibs.sh
@@ -65,7 +65,7 @@ SED_SCRIPT="/AM_CPPFLAGS = / {
 if HAVE_LOCAL_${LOCAL_LIB_UPPER}
 }
 
-/lib_LTLIBRARIES/ {
+/lib_LTLIBRARIES = / {
 	s/lib_LTLIBRARIES/noinst_LTLIBRARIES/
 }
 
@@ -103,6 +103,7 @@ endif
 	sed -i'~' -f ${LOCAL_LIB}-$$.sed ${LOCAL_LIB_MAKEFILE_AM};
 	rm -f ${LOCAL_LIB}-$$.sed;
 
+	sed -i'~' "/AM_CPPFLAGS = /,/noinst_LTLIBRARIES = / { N; s/\\\\\\n.@${LOCAL_LIB_UPPER}_DLL_EXPORT@//; P; D; }" ${LOCAL_LIB_MAKEFILE_AM};
 	sed -i'~' "/${LOCAL_LIB}_definitions.h.in/d" ${LOCAL_LIB_MAKEFILE_AM};
 	sed -i'~' "/${LOCAL_LIB}.rc/d" ${LOCAL_LIB_MAKEFILE_AM};
 
@@ -176,4 +177,3 @@ done
 IFS=$OLDIFS;
 
 exit ${EXIT_SUCCESS};
-


### PR DESCRIPTION
This PR extends the pwewf bindings by adding the `get_file_type` function to the `file_entry` objects. 

The change allows Python program to properly identify directories vs. files when working with file based archives such as LEF files. 

This change was developed on top of the package source distribution 20171104 and patched onto the master as I was running into the compilation problem described in #110.  