### PR TITLE
Allow ewfrecover to continue even if it cant detect the corruption

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,10 @@ Project information:
 * Status: experimental
 * Licence: LGPLv3+
 
+* Forked by Peter Theobald from libyal/libewf.
+     I encountered a corrupt E01 file. ewfexport quit with an error. ewfrecover refused to run because the file 'wasn't corrupt'
+     This fork modifies ewfrecover to that it reports the 'not corrupt' but makes the export anyway.
+
 Read or write supported EWF formats:
 
 * SMART .s01 (EWF-S01)

--- a/ewftools/ewfrecover.c
+++ b/ewftools/ewfrecover.c
@@ -478,7 +478,7 @@ int main( int argc, char * const argv[] )
 		 stderr,
 		 "Unable to determine if EWF file(s) are corrupted.\n" );
 
-		/* goto on_error; */
+		/* goto on_error; ** continue even if we cant detect the corruption */
 	}
 	else if( result == 0 )
 	{
@@ -486,7 +486,7 @@ int main( int argc, char * const argv[] )
 		 stderr,
 		 "EWF file(s) are not corrupted.\n" );
 
-		/* goto on_error; */
+		/* goto on_error; ** continue even if we cant detect the corruption */
 	}
 	ewfrecover_export_handle->output_format = EXPORT_HANDLE_OUTPUT_FORMAT_EWF;
 	ewfrecover_export_handle->export_size   = ewfrecover_export_handle->input_media_size;

--- a/ewftools/ewfrecover.c
+++ b/ewftools/ewfrecover.c
@@ -478,7 +478,7 @@ int main( int argc, char * const argv[] )
 		 stderr,
 		 "Unable to determine if EWF file(s) are corrupted.\n" );
 
-		goto on_error;
+		/* goto on_error; */
 	}
 	else if( result == 0 )
 	{
@@ -486,7 +486,7 @@ int main( int argc, char * const argv[] )
 		 stderr,
 		 "EWF file(s) are not corrupted.\n" );
 
-		goto on_error;
+		/* goto on_error; */
 	}
 	ewfrecover_export_handle->output_format = EXPORT_HANDLE_OUTPUT_FORMAT_EWF;
 	ewfrecover_export_handle->export_size   = ewfrecover_export_handle->input_media_size;


### PR DESCRIPTION
I encountered an E01 with corruption that ewfexport and ftkimager could not get past. ewfrecover refused to recover the E01 because it couldn't detect the corruption. This modification has ewfrecover report that it cannot detect the corruption, but continue with the recovery process as requested. I have tested it successfully on the corrupted E01.