### PR TITLE
man page ewfmount : add mount_point argument

### DIFF
--- a/manuals/ewfmount.1
+++ b/manuals/ewfmount.1
@@ -10,6 +10,7 @@
 .Op Fl X Ar extended_options
 .Op Fl hvV
 .Ar ewf_files
+.Ar mount_point
 .Sh DESCRIPTION
 .Nm ewfmount
 is a utility to mount data stored in EWF files.


### PR DESCRIPTION
I think the mount_point argument is missing in the SYNOPSIS of the ewfmount tools manuel page