### PR TITLE
Fixed a bug for the name prefix of the libodraw project

### DIFF
--- a/synclibs.ps1
+++ b/synclibs.ps1
@@ -74,7 +74,7 @@ ForEach (${LocalLib} in ${LocalLibs})
 			$OutputFile = ${DirectoryElement} -Replace ".l$",".c"
 
 			$NamePrefix = Split-Path -path ${DirectoryElement} -leaf
-			$NamePrefix = ${NamePrefix} -Replace "^${LocalLib}_",""
+			#$NamePrefix = ${NamePrefix} -Replace "^${LocalLib}_",""
 			$NamePrefix = ${NamePrefix} -Replace ".l$","_"
 
 			# PowerShell will raise NativeCommandError if win_flex writes to stdout or stderr


### PR DESCRIPTION
Recently, libodraw has been changed that it includes the project name as a prefix for function and variable names. However, synclibs.ps1 still removes the project name prefix before WinFlex is executed. Therefore, the compilation process of libodraw and ewfacquire failed. So I commented out the line for removing the prefix.