### PR TITLE
Fix a linking error of bzip2 on libewf

### DIFF
--- a/msvscpp/bzip2/bzip2.vcproj
+++ b/msvscpp/bzip2/bzip2.vcproj
@@ -19,7 +19,7 @@
 			Name="Release|Win32"
 			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
 			IntermediateDirectory="$(ConfigurationName)"
-			ConfigurationType="2"
+			ConfigurationType="4"
 			CharacterSet="1"
 			>
 			<Tool
@@ -56,7 +56,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				OutputFile="$(OutDir)\$(ProjectName).dll"
+				OutputFile="$(OutDir)\$(ProjectName).lib"
 				AdditionalLibraryDirectories="&quot;$(OutDir)&quot;"
 				RandomizedBaseAddress="2"
 				DataExecutionPrevention="2"
@@ -89,7 +89,7 @@
 			Name="VSDebug|Win32"
 			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
 			IntermediateDirectory="$(ConfigurationName)"
-			ConfigurationType="2"
+			ConfigurationType="4"
 			CharacterSet="1"
 			>
 			<Tool
@@ -130,7 +130,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				OutputFile="$(OutDir)\$(ProjectName).dll"
+				OutputFile="$(OutDir)\$(ProjectName).lib"
 				AdditionalLibraryDirectories="&quot;$(OutDir)&quot;"
 				GenerateDebugInformation="true"
 				RandomizedBaseAddress="1"


### PR DESCRIPTION
Although building bzip2 was successful when using build.ps1, the libewf compilation failed due to a linking error with like the message below.
```
LINK : fatal error LNK1104: cannot open file 'E:\devel\libyal\libewf_test\libewf\vs2022\Release\x64\bzip2.lib' [E:\devel\libyal\libewf_test\libewf\vs2022\libewf\libewf.vcxproj]
```

When I checked the cause, I found that the compiled bzip2.dll does not export any APIs. That's why bzip2.dll did not have bzip2.lib.
![bz2](https://github.com/libyal/libewf/assets/20717881/b7bd94b8-333d-42bc-8b11-3bc12e5536f2)

To avoid that, I simply changed the vcproj file DynamicLibrary to StaticLibrary. Then the error above was resolved.